### PR TITLE
get X509Certificate for alias in Android

### DIFF
--- a/android/src/main/kotlin/com/astrox/secure_p256_plugin/SecureP256Plugin.kt
+++ b/android/src/main/kotlin/com/astrox/secure_p256_plugin/SecureP256Plugin.kt
@@ -1,10 +1,10 @@
 package com.astrox.secure_p256_plugin
 
 import android.content.Context
-//import android.content.pm.PackageManager
 import android.os.Build
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
+import android.util.Base64
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -58,7 +58,7 @@ class SecureP256Plugin : FlutterPlugin, MethodCallHandler {
                 "getCertificate" -> {
                     val alias = call.argument<String>("tag")!!
                     val certificate = getCertificate(alias)
-                    result.success(certificate.encoded)
+                    result.success(Base64.encodeToString(certificate.encoded, Base64.NO_WRAP))
                 }
 
                 "sign" -> {

--- a/android/src/main/kotlin/com/astrox/secure_p256_plugin/SecureP256Plugin.kt
+++ b/android/src/main/kotlin/com/astrox/secure_p256_plugin/SecureP256Plugin.kt
@@ -13,6 +13,7 @@ import io.flutter.plugin.common.MethodChannel.Result
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.conscrypt.Conscrypt
 import java.security.*
+import java.security.cert.Certificate
 import java.security.spec.ECGenParameterSpec
 import java.security.spec.EncodedKeySpec
 import java.security.spec.X509EncodedKeySpec
@@ -52,6 +53,12 @@ class SecureP256Plugin : FlutterPlugin, MethodCallHandler {
                     val alias = call.argument<String>("tag")!!
                     val keyPair = getKeyPairFromAlias(alias)
                     result.success(keyPair.public.encoded)
+                }
+
+                "getCertificate" -> {
+                    val alias = call.argument<String>("tag")!!
+                    val certificate = getCertificate(alias)
+                    result.success(certificate.encoded)
                 }
 
                 "sign" -> {
@@ -183,6 +190,12 @@ class SecureP256Plugin : FlutterPlugin, MethodCallHandler {
         agreement.init(entry.privateKey)
         agreement.doPhase(publicKey, true)
         return agreement.generateSecret()
+    }
+
+    private fun getCertificate(alias: String): Certificate {
+        val ks: KeyStore = KeyStore.getInstance(storeProvider).apply { load(null) }
+        val entry = obtainPrivateKeyEntryFromAlias(alias, ks)
+        return entry.certificate as Certificate
     }
 
 //    private fun hasStrongBox(): Boolean {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -22,7 +22,7 @@ class _MyAppState extends State<MyApp> {
   String _publicKey = 'Unknown';
   String _signed = 'Unknown';
   bool? _verified;
-  String? _sharedSecret, _decrypted;
+  String? _certificate, _sharedSecret, _decrypted;
   Tuple2<Uint8List, Uint8List>? _encrypted;
 
   final _payloadTEC = TextEditingController(text: 'Hello world');
@@ -42,6 +42,7 @@ class _MyAppState extends State<MyApp> {
         body: ListView(
           children: [
             SelectableText('getPublicKey: $_publicKey\n'),
+            SelectableText('certificate: $_certificate\n'),
             SelectableText('sign: $_signed\n'),
             SelectableText('verify: $_verified\n'),
             SelectableText('sharedSecret: $_sharedSecret\n'),
@@ -74,6 +75,15 @@ class _MyAppState extends State<MyApp> {
                 );
               },
               child: const Text('getPublicKey'),
+            ),
+            ElevatedButton(
+              onPressed: () {
+                SecureP256.getCertificate(
+                  alias,
+                  Uint8List.fromList(utf8.encode(_verifyPayload)),
+                ).then((r) => setState(() => _certificate = r.toString()));
+              },
+              child: const Text('getCertificate'),
             ),
             ElevatedButton(
               onPressed: () {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,11 +1,14 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
-import 'package:agent_dart/identity/p256.dart';
+import 'package:agent_dart/agent_dart.dart';
+import 'package:asn1lib/asn1lib.dart' as asn1lib;
 import 'package:convert/convert.dart';
 import 'package:flutter/material.dart';
-import 'package:secp256r1/secp256r1.dart';
 import 'package:tuple/tuple.dart';
+import 'package:x509/x509.dart' as x509;
+
+import 'package:secp256r1/secp256r1.dart';
 
 void main() {
   runApp(const MyApp());
@@ -78,10 +81,14 @@ class _MyAppState extends State<MyApp> {
             ),
             ElevatedButton(
               onPressed: () {
-                SecureP256.getCertificate(
-                  alias,
-                  Uint8List.fromList(utf8.encode(_verifyPayload)),
-                ).then((r) => setState(() => _certificate = r.toString()));
+                SecureP256.getCertificate(alias).then(
+                  (r) => setState(() {
+                    final decoded = base64Decode(r.toString());
+                    final seq = asn1lib.ASN1Sequence.fromBytes(decoded);
+                    final cert = x509.X509Certificate.fromAsn1(seq);
+                    _certificate = cert.toString();
+                  }),
+                );
               },
               child: const Text('getCertificate'),
             ),

--- a/lib/p256_method_channel.dart
+++ b/lib/p256_method_channel.dart
@@ -20,10 +20,10 @@ class SecureP256Channel extends SecureP256Platform {
   }
 
   @override
-  Future<Uint8List> getCertificate(String tag, Uint8List payload) async {
+  Future<String> getCertificate(String tag) async {
     final signature = await methodChannel.invokeMethod(
       Methods.getCertificate,
-      {'tag': tag, 'payload': payload},
+      {'tag': tag},
     );
     return signature;
   }

--- a/lib/p256_method_channel.dart
+++ b/lib/p256_method_channel.dart
@@ -20,6 +20,15 @@ class SecureP256Channel extends SecureP256Platform {
   }
 
   @override
+  Future<Uint8List> getCertificate(String tag, Uint8List payload) async {
+    final signature = await methodChannel.invokeMethod(
+      Methods.getCertificate,
+      {'tag': tag, 'payload': payload},
+    );
+    return signature;
+  }
+
+  @override
   Future<Uint8List> sign(String tag, Uint8List payload) async {
     final signature = await methodChannel.invokeMethod(
       Methods.sign,

--- a/lib/p256_platform_interface.dart
+++ b/lib/p256_platform_interface.dart
@@ -29,6 +29,10 @@ abstract class SecureP256Platform extends PlatformInterface {
     return _instance.getPublicKey(tag);
   }
 
+  Future<dynamic> getCertificate(String tag, Uint8List payload) {
+    return _instance.getCertificate(tag, payload);
+  }
+
   Future<Uint8List> sign(String tag, Uint8List payload) {
     return _instance.sign(tag, payload);
   }

--- a/lib/p256_platform_interface.dart
+++ b/lib/p256_platform_interface.dart
@@ -29,8 +29,8 @@ abstract class SecureP256Platform extends PlatformInterface {
     return _instance.getPublicKey(tag);
   }
 
-  Future<dynamic> getCertificate(String tag, Uint8List payload) {
-    return _instance.getCertificate(tag, payload);
+  Future<dynamic> getCertificate(String tag) {
+    return _instance.getCertificate(tag);
   }
 
   Future<Uint8List> sign(String tag, Uint8List payload) {

--- a/lib/secp256r1.dart
+++ b/lib/secp256r1.dart
@@ -23,6 +23,14 @@ class SecureP256 {
     }
   }
 
+  static Future<dynamic> getCertificate(String tag, Uint8List payload) async {
+    assert(tag.isNotEmpty);
+    assert(payload.isNotEmpty);
+    final certificate =
+        await SecureP256Platform.instance.getCertificate(tag, payload);
+    return certificate;
+  }
+
   static Future<Uint8List> sign(String tag, Uint8List payload) async {
     assert(tag.isNotEmpty);
     assert(payload.isNotEmpty);

--- a/lib/secp256r1.dart
+++ b/lib/secp256r1.dart
@@ -23,11 +23,9 @@ class SecureP256 {
     }
   }
 
-  static Future<dynamic> getCertificate(String tag, Uint8List payload) async {
+  static Future<String> getCertificate(String tag) async {
     assert(tag.isNotEmpty);
-    assert(payload.isNotEmpty);
-    final certificate =
-        await SecureP256Platform.instance.getCertificate(tag, payload);
+    final certificate = await SecureP256Platform.instance.getCertificate(tag);
     return certificate;
   }
 

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -3,6 +3,7 @@ class Methods {
 
   static const getPublicKey = 'getPublicKey';
   static const sign = 'sign';
+  static const getCertificate = 'getCertificate';
   static const verify = 'verify';
   static const getSharedSecret = 'getSharedSecret';
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,15 +5,17 @@ version: 0.1.0-dev.7
 repository: https://github.com/AstroxNetwork/flutter_secp256r1
 
 environment:
-  sdk: '>=2.13.0 <4.0.0'
-  flutter: '>=2.0.0'
+  sdk: ">=2.13.0 <4.0.0"
+  flutter: ">=2.0.0"
 
 dependencies:
+  asn1lib: ^1.5.2
   flutter:
     sdk: flutter
   agent_dart: ^1.0.0-dev.8
   plugin_platform_interface: ^2.0.2
   tuple: ^2.0.0
+  x509: ^0.2.4+2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The X509 digital certificate uses the X.509 public key infrastructure (PKI) standard to verify that a public key belongs to a user, device, or service.